### PR TITLE
Adds initial composer setup.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Build & test
+
+on: [push, pull_request]
+
+jobs:
+  php:
+    strategy:
+      matrix:
+        php: ['7.2', '7.3', '7.4', '8.0']
+      fail-fast: false
+    name: PHP test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+      - uses: actions/checkout@v2
+      - name: Debugging
+        run: |
+          php --version
+          php -m
+          composer --version
+      - name: Composer validate
+        run: composer validate --strict
+      - name: Composer install
+        run: composer install --no-suggest

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea
+
+/vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "level-level/postman",
+    "description": "Adapter between WordPress mail and several mail service providers.",
+    "type": "wordpress-plugin",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Level Level",
+            "email": "info@level-level.com"
+        }
+    ],
+    "require": {}
+}


### PR DESCRIPTION
GitHub actions verifies the composer file. Composer.lock is ignored, as this will be used as a library, allowing the dependents to specify their own locked versions.